### PR TITLE
feat: update zeno overview + dark support

### DIFF
--- a/docs/intro/intro.mdx
+++ b/docs/intro/intro.mdx
@@ -13,8 +13,9 @@ Zeno can be used for any data type or task with [modular views](/docs/views/) fo
 See the [Getting Started](/docs/intro/get_started) and [CIFAR-10 Example](/docs/intro/cifar) pages to set up Zeno and learn about the core concepts.
 
 <img
-  style={{ border: "1px solid #e8e8e8", padding: "5px", borderRadius: "3px" }}
-  src="/img/overall.png"
+	style={{ border: "1px solid #e8e8e8", padding: "5px", borderRadius: "3px" }}
+	src="/img/overall.png"
+	className={"color-invert"}
 />
 
 ## Key Features
@@ -66,22 +67,22 @@ def brightness(df, ops):
 ### Analysis UI
 
 <div style={{ display: "flex" }}>
-  <img
-    style={{
-      padding: "5px",
-      width: "50%",
-      marginRight: "20px",
-      objectFit: "contain",
-    }}
-    src="/img/analyze.png"
-  />
-  <p>
-    The Analysis UI is used to compare models over time and create
-    <i> behavioral unit tests</i>. You can create reports for groups of instance
-    and see how new models compare with sparkline visualizations and trends. To catch
-    potential regressions, you can create tests of expected metrics for slices. Reports
-    can be shared and exported as PDFs.
-  </p>
+	<img
+		style={{
+			padding: "5px",
+			width: "50%",
+			marginRight: "20px",
+			objectFit: "contain",
+		}}
+		src="/img/analyze.png"
+	/>
+	<p>
+		The Analysis UI is used to compare models over time and create
+		<i> behavioral unit tests</i>. You can create reports for groups of instance
+		and see how new models compare with sparkline visualizations and trends.
+		To catch potential regressions, you can create tests of expected metrics
+		for slices. Reports can be shared and exported as PDFs.
+	</p>
 </div>
 
 ## Why Zeno?

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -47,3 +47,8 @@
   height: 24px;
   width: 24px;
 }
+
+[data-theme="dark"] .color-invert {
+  filter: invert(1);
+  mix-blend-mode: exclusion;
+}


### PR DESCRIPTION
This figure needs to be updated anyway, I haven't gotten to that, but have added a potential way for supporting the dark mode with css invert magic.

Yeah so don't merge this yet. Just needed to open it so I could refer to it in this issue #6 
<img width="1792" alt="invert" src="https://user-images.githubusercontent.com/65095341/209474592-ab4821f8-05e6-4e2b-a27e-b15925ff410a.png">

**Case for Css invert**
Making a darkmode figure each time is a bit of a pain. And this css can be applied to future images (or all images if you want).

**Case AGAINST Css invert**
Looks out of place with the green if everything else is purple. 
