### PR TITLE
feat: add trending projects and reports to homepage

### DIFF
--- a/src/components/Trending/Trending.tsx
+++ b/src/components/Trending/Trending.tsx
@@ -1,0 +1,22 @@
+import { Header } from "@site/src/pages";
+import React from "react";
+import styles from "./styles.module.css";
+
+export function Trending(props) {
+  return (
+    <div className={styles.container}>
+      <Header
+        title="Trending"
+        summary="Trending"
+        description="Explore trending reports and projects on Zeno."
+      ></Header>
+      <div className={styles.iframe}>
+        <iframe
+          height="250"
+          width="100%"
+          src="https://hub.zenoml.com/embed/entry/featured/4"
+        ></iframe>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Trending/styles.module.css
+++ b/src/components/Trending/styles.module.css
@@ -1,0 +1,9 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.iframe {
+  display: flex;
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,6 +4,7 @@ import { HomepageHeader } from "@site/src/components/HomepageHeader/HomepageHead
 import ReportSelect from "@site/src/components/ReportSelect";
 import { Sections } from "@site/src/components/Sections/Sections";
 import { Sponsors } from "@site/src/components/Sponsors/Sponsors";
+import { Trending } from "@site/src/components/Trending/Trending";
 
 import Layout from "@theme/Layout";
 import React from "react";
@@ -23,6 +24,8 @@ export default function Home(): JSX.Element {
       <div id="homepage">
         <HomepageHeader />
         <div id="pageWrapper">
+          <Trending />
+          <hr />
           <Sections />
           <hr />
           <DatatypeSelect />


### PR DESCRIPTION
<img width="1419" alt="image" src="https://github.com/zeno-ml/zenoml.com/assets/5690524/0a6dfb91-7285-44ba-85a5-e0bfe37a5b94">

Works for different screen sizes as well but is not always super beautiful. Don't know if we need to fix that now, though. Kinda tricky with iframes.

fix ZEN-280